### PR TITLE
Introduce republish hooks

### DIFF
--- a/src/post-republisher.php
+++ b/src/post-republisher.php
@@ -256,7 +256,7 @@ class Post_Republisher {
 	 */
 	public function republish( WP_Post $post, WP_Post $original_post ) {
 		
-		do_action('dp_republish_start', $post, $original_post);
+		\do_action( 'dp_republish_start', $post, $original_post);
 		
 		// Remove WordPress default filter so a new revision is not created on republish.
 		\remove_action( 'post_updated', 'wp_save_post_revision', 10 );
@@ -274,7 +274,7 @@ class Post_Republisher {
 		// Re-enable the creation of a new revision.
 		\add_action( 'post_updated', 'wp_save_post_revision', 10, 1 );
 		
-		do_action('dp_republish_done', $post, $original_post);
+		\do_action( 'dp_republish_done', $post, $original_post);
 	}
 
 	/**

--- a/src/post-republisher.php
+++ b/src/post-republisher.php
@@ -255,6 +255,9 @@ class Post_Republisher {
 	 * @return void
 	 */
 	public function republish( WP_Post $post, WP_Post $original_post ) {
+		
+		do_action('dp_republish_start', $post, $original_post);
+		
 		// Remove WordPress default filter so a new revision is not created on republish.
 		\remove_action( 'post_updated', 'wp_save_post_revision', 10 );
 
@@ -270,6 +273,8 @@ class Post_Republisher {
 
 		// Re-enable the creation of a new revision.
 		\add_action( 'post_updated', 'wp_save_post_revision', 10, 1 );
+		
+		do_action('dp_republish_done', $post, $original_post);
 	}
 
 	/**


### PR DESCRIPTION
## Context

This PR introduces two action  hooks `dp_republish_start` and `dp_republish_done` to the republish method. A developer can hook into the republish cycle at the beginning or end when a post gets republished.

We needed to hook into the republish cycle of the plugin to trigger cache invalidation steps after a post gets republished. unfortunately the  wp `save_post` hook was not enough for our case because  some of the meta fields still got copied over while the main article content was already finished copying over its original content. In some cases (very large posts with a couple of 100 meta field entries) this could lead to a raise condition were the cache was invalidated but did not show the complete republished update of that post.